### PR TITLE
llvm: LoongArch: fix semantics with fmax/fmin/fmaxa/fmina

### DIFF
--- a/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
+++ b/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
@@ -308,6 +308,11 @@ LoongArchTargetLowering::LoongArchTargetLowering(const LoongArchTargetMachine &T
   setOperationAction(ISD::FREM,              MVT::f32,   Expand);
   setOperationAction(ISD::FREM,              MVT::f64,   Expand);
 
+  setOperationAction(ISD::FMINNUM_IEEE,      MVT::f32,   Legal);
+  setOperationAction(ISD::FMINNUM_IEEE,      MVT::f64,   Legal);
+  setOperationAction(ISD::FMAXNUM_IEEE,      MVT::f32,   Legal);
+  setOperationAction(ISD::FMAXNUM_IEEE,      MVT::f64,   Legal);
+
   // Lower f16 conversion operations into library calls
   setOperationAction(ISD::FP16_TO_FP,        MVT::f32,   Expand);
   setOperationAction(ISD::FP_TO_FP16,        MVT::f32,   Expand);

--- a/llvm/lib/Target/LoongArch/LoongArchInstrInfoF.td
+++ b/llvm/lib/Target/LoongArch/LoongArchInstrInfoF.td
@@ -140,12 +140,10 @@ class FSTX<string opstr, RegisterOperand DRC,
 }
 
 /// f{maxa/mina}.{s/d}
-class Float_Reg3_Fmaxa<string opstr, RegisterOperand RO,
-                 SDPatternOperator OpNode= null_frag>
+class Float_Reg3_Fmaxa<string opstr, RegisterOperand RO>
     : InstForm<(outs RO:$fd), (ins RO:$fj, RO:$fk),
           !strconcat(opstr, "\t$fd, $fj, $fk"),
-          [(set RO:$fd, (OpNode (fabs RO:$fj), (fabs RO:$fk)))],
-          FrmR, opstr>;
+          [], FrmR, opstr>;
 /// frecip
 class Float_Reg2_Frecip<string opstr, RegisterOperand RO,
                  SDPatternOperator OpNode= null_frag>
@@ -353,10 +351,10 @@ def FMAX_S      : Float_Reg3<"fmax.s", FGR32Opnd, fmaximum>, R3F<0b010001>;
 def FMAX_D      : Float_Reg3<"fmax.d", FGR64Opnd, fmaximum>, R3F<0b010010>;
 def FMIN_S      : Float_Reg3<"fmin.s", FGR32Opnd, fminimum>, R3F<0b010101>;
 def FMIN_D      : Float_Reg3<"fmin.d", FGR64Opnd, fminimum>, R3F<0b010110>;
-def FMAXA_S     : Float_Reg3_Fmaxa<"fmaxa.s", FGR32Opnd, fmaximum>, R3F<0b011001>;
-def FMAXA_D     : Float_Reg3_Fmaxa<"fmaxa.d", FGR64Opnd, fmaximum>, R3F<0b011010>;
-def FMINA_S     : Float_Reg3_Fmaxa<"fmina.s", FGR32Opnd, fminimum>, R3F<0b011101>;
-def FMINA_D     : Float_Reg3_Fmaxa<"fmina.d", FGR64Opnd, fminimum>, R3F<0b011110>;
+def FMAXA_S     : Float_Reg3_Fmaxa<"fmaxa.s", FGR32Opnd>, R3F<0b011001>;
+def FMAXA_D     : Float_Reg3_Fmaxa<"fmaxa.d", FGR64Opnd>, R3F<0b011010>;
+def FMINA_S     : Float_Reg3_Fmaxa<"fmina.s", FGR32Opnd>, R3F<0b011101>;
+def FMINA_D     : Float_Reg3_Fmaxa<"fmina.d", FGR64Opnd>, R3F<0b011110>;
 def FSCALEB_S   : Float_Reg3<"fscaleb.s", FGR32Opnd>, R3F<0b100001>;
 def FSCALEB_D   : Float_Reg3<"fscaleb.d", FGR64Opnd>, R3F<0b100010>;
 def FCOPYSIGN_S : Float_Reg3<"fcopysign.s", FGR32Opnd, fcopysign>, R3F<0b100101>;

--- a/llvm/lib/Target/LoongArch/LoongArchInstrInfoF.td
+++ b/llvm/lib/Target/LoongArch/LoongArchInstrInfoF.td
@@ -347,10 +347,10 @@ def FMUL_S      : Float_Reg3<"fmul.s", FGR32Opnd, fmul>, R3F<0b001001>;
 def FMUL_D      : Float_Reg3<"fmul.d", FGR64Opnd, fmul>, R3F<0b001010>;
 def FDIV_S      : Float_Reg3<"fdiv.s", FGR32Opnd, fdiv>, R3F<0b001101>;
 def FDIV_D      : Float_Reg3<"fdiv.d", FGR64Opnd, fdiv>, R3F<0b001110>;
-def FMAX_S      : Float_Reg3<"fmax.s", FGR32Opnd, fmaximum>, R3F<0b010001>;
-def FMAX_D      : Float_Reg3<"fmax.d", FGR64Opnd, fmaximum>, R3F<0b010010>;
-def FMIN_S      : Float_Reg3<"fmin.s", FGR32Opnd, fminimum>, R3F<0b010101>;
-def FMIN_D      : Float_Reg3<"fmin.d", FGR64Opnd, fminimum>, R3F<0b010110>;
+def FMAX_S      : Float_Reg3<"fmax.s", FGR32Opnd, fmaxnum_ieee>, R3F<0b010001>;
+def FMAX_D      : Float_Reg3<"fmax.d", FGR64Opnd, fmaxnum_ieee>, R3F<0b010010>;
+def FMIN_S      : Float_Reg3<"fmin.s", FGR32Opnd, fminnum_ieee>, R3F<0b010101>;
+def FMIN_D      : Float_Reg3<"fmin.d", FGR64Opnd, fminnum_ieee>, R3F<0b010110>;
 def FMAXA_S     : Float_Reg3_Fmaxa<"fmaxa.s", FGR32Opnd>, R3F<0b011001>;
 def FMAXA_D     : Float_Reg3_Fmaxa<"fmaxa.d", FGR64Opnd>, R3F<0b011010>;
 def FMINA_S     : Float_Reg3_Fmaxa<"fmina.s", FGR32Opnd>, R3F<0b011101>;
@@ -622,3 +622,6 @@ def : LoongArchPat<(LoongArchTruncIntFP FGR64Opnd:$src),
 
 def : LoongArchPat<(LoongArchTruncIntFP FGR32Opnd:$src),
               (FTINTRZ_L_S FGR32Opnd:$src)>;
+
+def : Pat<(fcanonicalize FGR32Opnd:$src), (FMAX_S $src, $src)>;
+def : Pat<(fcanonicalize FGR64Opnd:$src), (FMAX_D $src, $src)>;


### PR DESCRIPTION
maximum(fabs(-2.0), fabs(1.0)) should be 2.0.  However fmaxa gives -2.0.

We need an additional abs instruction to make it correct.